### PR TITLE
Fix fd_forwarder to not send padded null bytes

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -15,7 +15,7 @@ dev-term:
   ./hermes/target/debug/hermes
 
 fmt:
-  #!/usr/bin/env bash
+  #!/bin/bash
   for project in {{projects}}; do
     cd $project
     cargo fmt
@@ -23,14 +23,14 @@ fmt:
   done
 
 rust_release_file_size:
-  #!/usr/bin/env bash
+  #!/bin/bash
   for project in {{projects}}; do
     size=$(cd $project && ls -alih target/release/$project | awk '{print $6}')
     echo "Size of $project := $size"
   done
 
 clean:
-  #!/usr/bin/env bash
+  #!/bin/bash
   for project in {{projects}}; do
     cd $project
     cargo clean

--- a/common/src/forwarder.rs
+++ b/common/src/forwarder.rs
@@ -11,6 +11,8 @@ pub fn start_forwarder(from_fd: i32, to_fd: i32) {
 		"Request to start forward from : {}, to : {}",
 		from_fd, to_fd
 	);
+	let mut buf: [u8; 512] = [0; 512];
+
 	loop {
 		let in_fd = PollFd::new(borrowed_fd!(from_fd), PollFlags::POLLIN);
 
@@ -23,11 +25,9 @@ pub fn start_forwarder(from_fd: i32, to_fd: i32) {
 			continue;
 		}
 
-		let mut buf: [u8; 512] = [0; 512];
-
-		let bytes_read = read(from_fd, &mut buf);
-		if bytes_read.unwrap_or(0) > 0 {
-			let _ = write(borrowed_fd!(to_fd).as_fd(), &buf);
+		let bytes_read = read(from_fd, &mut buf).unwrap_or(0);
+		if bytes_read > 0 {
+			let _ = write(borrowed_fd!(to_fd).as_fd(), &buf[0..bytes_read]);
 		}
 	}
 }

--- a/hermes/src/core/init.rs
+++ b/hermes/src/core/init.rs
@@ -83,27 +83,40 @@ fn init_keymapper() -> Result<KeyMapper, InitializationError> {
 		);
 	}
 
+	for character in ctrl_chars::CTRL_ALL_CHARS.iter() {
+		if *character == general_ascii_chars::ESC
+			|| *character == general_ascii_chars::EOF
+			|| *character == general_ascii_chars::NEWLINE
+		{
+			continue;
+		}
+		key_mapper.register_binding(
+				&[*character],
+				Box::new(move || KeypressAction::Return(*character))
+			);
+	}
+
 	// Essential linux shell signals mapping
-	catch_error!(
-		key_mapper.register_binding(
-			&[ctrl_chars::CTRL_C],
-			Box::new(move || KeypressAction::Signal(SIGNAL::SIGINT)),
-		) => InitializationError{}
-	);
+	// catch_error!(
+	// 	key_mapper.register_binding(
+	// 		&[ctrl_chars::CTRL_C],
+	// 		Box::new(move || KeypressAction::Signal(SIGNAL::SIGINT)),
+	// 	) => InitializationError{}
+	// );
 
-	catch_error!(
-		key_mapper.register_binding(
-			&[ctrl_chars::CTRL_Z],
-			Box::new(move || KeypressAction::Signal(SIGNAL::SIGSTOP)),
-		) => InitializationError{}
-	);
+	// catch_error!(
+	// 	key_mapper.register_binding(
+	// 		&[ctrl_chars::CTRL_Z],
+	// 		Box::new(move || KeypressAction::Signal(SIGNAL::SIGSTOP)),
+	// 	) => InitializationError{}
+	// );
 
-	catch_error!(
-		key_mapper.register_binding(
-		&[ctrl_chars::CTRL_D],
-		Box::new(move || KeypressAction::Signal(SIGNAL::SIGQUIT)),
-		) => InitializationError{}
-	);
+	// catch_error!(
+	// 	key_mapper.register_binding(
+	// 	&[ctrl_chars::CTRL_D],
+	// 	Box::new(move || KeypressAction::Signal(SIGNAL::SIGQUIT)),
+	// 	) => InitializationError{}
+	// );
 
 	// multi-char actions
 	catch_error!(

--- a/hermes/src/core/socket.rs
+++ b/hermes/src/core/socket.rs
@@ -42,7 +42,7 @@ pub fn start_socket_forwarding(socket: UnixStream, read_fd: OwnedFd) {
 
 	let (in_task, out_task) = (
 		thread::spawn(move || {
-			start_socket_write_forwarding(socket_fd_in, read_fd);
+			start_forwarder(socket_fd_in, read_fd.as_raw_fd());
 		}),
 		thread::spawn(move || {
 			start_forwarder(socket_fd_out, STDOUT_FILENO);
@@ -50,16 +50,4 @@ pub fn start_socket_forwarding(socket: UnixStream, read_fd: OwnedFd) {
 	);
 	let _ = in_task.join();
 	let _ = out_task.join();
-}
-
-fn start_socket_write_forwarding(socket_fd: i32, read_fd: OwnedFd) {
-	let mut buf: [u8; 1] = [0; 1];
-	loop {
-		let read_bytes = read(read_fd.as_raw_fd(), &mut buf);
-		if let Ok(read_cnt) = read_bytes {
-			if read_cnt > 0 {
-				let _ = write(borrowed_fd!(socket_fd), &buf[0..read_cnt]);
-			}
-		}
-	}
 }

--- a/zeus/src/core/service/shell.rs
+++ b/zeus/src/core/service/shell.rs
@@ -1,7 +1,6 @@
 use std::{
 	ffi::{CStr, CString},
 	os::{fd::AsRawFd, unix::net::UnixStream},
-	str::FromStr,
 };
 
 use common::{


### PR DESCRIPTION
fix #3
* (commons) fd_forwarder sending bytes not belonging to the current read
* (zeus) refactor to use fd_forwarder instead of custom logic and buffer size
* (hermes) refactor to use fd_forwarder instead of custom logic and buffer size